### PR TITLE
Add GitHub Actions workflow file

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -1,0 +1,103 @@
+name: Build VCV Rack Plugin
+on: [push, pull_request]
+
+env:
+  rack-sdk-version: 1.1.6
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+        - {
+            name: Linux,
+            os: ubuntu-latest,
+            prepare-os: sudo apt install -y libglu-dev
+          }
+        - {
+            name: MacOS,
+            os: macos-latest,
+            prepare-os: ""
+          }
+        - {
+            name: Windows,
+            os: windows-latest,
+            prepare-os: export CC=gcc
+          }
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Get Rack-SDK
+        run: |
+          pushd $HOME
+          curl -o Rack-SDK.zip https://vcvrack.com/downloads/Rack-SDK-${{ env.rack-sdk-version }}.zip
+          unzip Rack-SDK.zip
+      - name: Patch plugin.mk, use 7zip on Windows
+        if: runner.os == 'Windows'
+        run: |
+          sed -i 's/zip -q -9 -r/7z a -tzip -mx=9/' $HOME/Rack-SDK/plugin.mk
+      - name: Modify plugin version
+        # only modify plugin version if no tag was created
+        if: "! startsWith(github.ref, 'refs/tags/v')"
+        run: |
+          gitrev=`git rev-parse --short HEAD`
+          pluginversion=`jq -r '.version' plugin.json`
+          echo "Set plugin version from $pluginversion to $pluginversion-$gitrev"
+          cat <<< `jq --arg VERSION "$pluginversion-$gitrev" '.version=$VERSION' plugin.json` > plugin.json
+      - name: Build plugin
+        run: |
+          ${{ matrix.config.prepare-os }}
+          export RACK_DIR=$HOME/Rack-SDK
+          make -j dep
+          make -j dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist
+          name: ${{ matrix.config.name }}
+
+  publish:
+    name: Publish plugin
+    # only create a release if a tag was created that is called e.g. v1.2.3
+    # see also https://vcvrack.com/manual/Manifest#version
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: FranzDiebold/github-env-vars-action@v1.2.1
+      - name: Check if plugin version matches tag
+        run: |
+          pluginversion=`jq -r '.version' plugin.json`
+          if [ "v$pluginversion" != "${{ env.GITHUB_REF_NAME }}" ]; then
+            echo "Plugin version from plugin.json 'v$pluginversion' doesn't match with tag version '${{ env.GITHUB_REF_NAME }}'"
+            exit 1
+          fi
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            ${{ env.GITHUB_REPOSITORY_NAME }} VCV Rack Plugin ${{ env.GITHUB_REF_NAME }}
+          draft: false
+          prerelease: false
+      - uses: actions/download-artifact@v2
+        with:
+          path: _artifacts
+      - name: Upload release assets
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _artifacts/**/*.zip
+          tag: ${{ github.ref }}
+          file_glob: true

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "AlliewayAudio_Freebies",
   "name": "AlliewayAudio_Freebies",
-  "version": "1.0.0-beta3",
+  "version": "1.0.0-beta4.hotfix",
   "license": "GPL-3.0-or-later",
   "brand": "AlliewayAudio",
   "author": "Allie",


### PR DESCRIPTION
There are a few different ways to approach using GitHub Actions to build VCV Rack plugins -- I was originally going to suggest something like [my setup](https://github.com/Dewb/monome-rack/tree/main/.github), which has explicit Dockerfiles for every platform, and macOS cross-compilation from Linux. But qno's approach in [vcv-plugin-github-actions-example](https://github.com/qno/vcv-plugin-github-actions-example) is *dramatically* simpler, just a single file.

It also adds a nice version tagging feature -- if you didn't tag a commit with a release number, it will update the plugin.json with a commit hash, and if you did tag the latest commit and it matches the version string in plugin.json, it will publish a new release. 

Or at least that's how I interpret how it's supposed to work -- documentation is a little thin, so let's see what happens! 

If you merge this PR, I would expect it build the plugin for all three platforms and make them available as "artifacts" on the workflow in the Actions tab. Those won't be kept forever, but they'll stick around for a few days. Then, if you push a new commit that updates the version to "1.0.0-beta5" and also includes a git tag for "1.0.0-beta5", it should build again and post those .zips to a new release on the releases page.