### PR TITLE
Add the term "Hardware clone" to the tags of Chilly Cheese

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -21,6 +21,7 @@
         "Attenuator",
         "Compressor",
         "Envelope follower",
+        "Hardware clone",
         "Logic",
         "Ring modulator",
         "Slew limiter",


### PR DESCRIPTION
Since Chilly Cheese is a recreation of Cold Mac, It might be appropriate to add the "Hardware Clone" tag to the module. 